### PR TITLE
fixed warning errors for picked item and image notification

### DIFF
--- a/scenes/formes/bureau_tiroir.gd
+++ b/scenes/formes/bureau_tiroir.gd
@@ -114,6 +114,7 @@ func collect_first_item():
 
 	prints(current_items)
 	if item.has_method("_prendre"):
+		_add_prenre_to_SceneTree(item)
 		item._prendre()
 		current_items.remove_at(0)
 
@@ -129,6 +130,7 @@ func collect_other_items():
 
 		send_player_notifiction_image()
 
+		_add_prenre_to_SceneTree(item)
 		item._prendre()
 		current_items.remove_at(i)
 		#prints(current_items,"-", item)
@@ -157,3 +159,6 @@ func _process(_delta):
 				notification_opened = false
 
  
+
+func _add_prenre_to_SceneTree(_item):
+	self.add_child(_item)

--- a/scenes/misc/caisse_ouvrable.gd
+++ b/scenes/misc/caisse_ouvrable.gd
@@ -114,6 +114,7 @@ func collect_first_item():
 
 	prints(current_items)
 	if item.has_method("_prendre"):
+		_add_prenre_to_SceneTree(item)
 		item._prendre()
 		current_items.remove_at(0)
 
@@ -129,6 +130,7 @@ func collect_other_items():
 
 		send_player_notifiction_image()
 
+		_add_prenre_to_SceneTree(item)
 		item._prendre()
 		current_items.remove_at(i)
 		#prints(current_items,"-", item)
@@ -157,3 +159,6 @@ func _process(_delta):
 				notification_opened = false
 
  
+
+func _add_prenre_to_SceneTree(_item):
+	self.add_child(_item)

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -27,7 +27,6 @@ const crouch_translate = 0.325
 const crouch_jump_add = crouch_translate * 0.74
 var is_crouched := false
 
-var notification_sprite = Sprite2D.new()
 
 func _ready():
 	get_tree().call_group("monstres", "set_player", self)
@@ -417,6 +416,7 @@ func _on_anim_in_gas_animation_finished(_anim_name: StringName) -> void:
 
 
 func show_notification_crate_image(image_path:String):
+	var notification_sprite = Sprite2D.new()
 	get_parent().get_node("Notification_Control").show()
 	
 	var text_rect: TextureRect = get_parent().get_node("Notification_Control/notification_image")
@@ -445,6 +445,11 @@ func show_notification_crate_image(image_path:String):
 	else:
 		notification_sprite.frame = 1
 	
+	# lets remove the former children sprites if any
+	if text_rect.get_child_count() > 0:
+		for _child in text_rect.get_children():
+			_child.queue_free()
+		
 	text_rect.add_child(notification_sprite)
 	notification_sprite.position = Vector2.ZERO + (text_rect.size/2)
 	


### PR DESCRIPTION
Fixed issue when items are picked and the timer or sound fails because the node is not in the scene tree. Also fixed the notification images warning error that happens when adding to existing image.